### PR TITLE
Ensure DPO TensorBoard logs use scalar values

### DIFF
--- a/cosyvoice/utils/train_utils.py
+++ b/cosyvoice/utils/train_utils.py
@@ -271,6 +271,8 @@ def batch_forward(model, batch, scaler, info_dict, ref_model=None, dpo_loss=None
             info_dict['loss_dict']["dpo_acc"] = dpo_acc
             info_dict['loss_dict']["chosen_reward"] = chosen_reward.mean()
             info_dict['loss_dict']["reject_reward"] = reject_reward.mean()
+            info_dict['loss_dict']["chosen_logps"] = chosen_logps.detach().mean().item()
+            info_dict['loss_dict']["rejected_logps"] = rejected_logps.detach().mean().item()
     return info_dict
 
 
@@ -335,7 +337,14 @@ def log_per_step(writer, info_dict):
             for k in ['epoch', 'lr', 'grad_norm']:
                 writer.add_scalar('{}/{}'.format(tag, k), info_dict[k], step + 1)
             for k, v in loss_dict.items():
-                writer.add_scalar('{}/{}'.format(tag, k), v, step + 1)
+                value = v
+                if isinstance(value, torch.Tensor):
+                    if value.ndim > 0:
+                        value = value.mean()
+                    if value.requires_grad:
+                        value = value.detach()
+                    value = value.item()
+                writer.add_scalar('{}/{}'.format(tag, k), value, step + 1)
 
     # TRAIN & CV, Shell log (stdout)
     if (info_dict['batch_idx'] + 1) % info_dict['log_interval'] == 0:
@@ -364,4 +373,11 @@ def log_per_save(writer, info_dict):
         for k in ['epoch', 'lr']:
             writer.add_scalar('{}/{}'.format(tag, k), info_dict[k], step + 1)
         for k, v in loss_dict.items():
-            writer.add_scalar('{}/{}'.format(tag, k), v, step + 1)
+            value = v
+            if isinstance(value, torch.Tensor):
+                if value.ndim > 0:
+                    value = value.mean()
+                if value.requires_grad:
+                    value = value.detach()
+                value = value.item()
+            writer.add_scalar('{}/{}'.format(tag, k), value, step + 1)


### PR DESCRIPTION
## Summary
- convert DPO chosen/rejected log probabilities to detached scalar means before storing in the loss dictionary
- reduce tensor metrics to scalars before logging them to TensorBoard in both per-step and per-save paths

## Testing
- python - <<'PY' ... (dummy DPO step to verify TensorBoard logging)


------
https://chatgpt.com/codex/tasks/task_e_68df3785646c8330b86195095dc59abc